### PR TITLE
Use floor division in bytesToTest()

### DIFF
--- a/src/static/boilerplate.py
+++ b/src/static/boilerplate.py
@@ -693,7 +693,7 @@ def bytesToTest(self, data, swarm=False):
         self.standardSwarm(R)
         data = data[4:]
         alen = len(self.actions())
-    for i in range(0,(len(data)/bytes)):
+    for i in range(0,(len(data)//bytes)):
         index = struct.unpack(fmt,data[i*bytes:(i*bytes)+bytes])[0] % alen
         test.append(self.actions()[index])
     return test


### PR DESCRIPTION
In Python 3, the `/` operator yields float, which causes:

    TypeError: 'float' object cannot be interpreted as an integer